### PR TITLE
Lodash version

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   { "node": ">0.6.0"
   }
 , "dependencies":
-  { "lodash": "~0.9"
+  { "lodash": "0.9.0"
   },
   "devDependencies":
   { "mocha": "*"


### PR DESCRIPTION
As of 9.2 Lodash has become quite sensitive to the nodejs install location, which means installations of node configured by n or nave are rather unreliable. The Lodash module author has yet to fix the issue, can we roll it back until the issue is resolved?
